### PR TITLE
Parse From display name into from_name

### DIFF
--- a/lib/sendgrid-actionmailer.rb
+++ b/lib/sendgrid-actionmailer.rb
@@ -17,10 +17,13 @@ module SendGridActionMailer
     end
 
     def deliver!(mail)
+      from = mail[:from].tree.addresses.first
+
       email = SendGrid::Mail.new do |m|
-        m.to      = mail[:to].addresses
-        m.from    = mail[:from].value
-        m.subject = mail.subject
+        m.to        = mail[:to].addresses
+        m.from      = from.address
+        m.from_name = from.display_name
+        m.subject   = mail.subject
       end
 
       # TODO: This is pretty ugly

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'mail', '~>2.5.3'
   spec.add_dependency 'sendgrid-ruby', '~> 0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'mail', '~>2.6.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~>3.2.0'
 end

--- a/spec/lib/sendgrid-actionmailer-spec.rb
+++ b/spec/lib/sendgrid-actionmailer-spec.rb
@@ -47,6 +47,20 @@ module SendGridActionMailer
         expect(client.sent_mail.from).to eq('taco@cat.limo')
       end
 
+      context 'from contains a friendly name' do
+        before { mail.from = 'Taco Cat <taco@cat.limo>'}
+
+        it 'sets from' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.from).to eq('taco@cat.limo')
+        end
+
+        it 'sets from_name' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.from_name).to eq('Taco Cat')
+        end
+      end
+
       it 'sets subject' do
         mailer.deliver!(mail)
         expect(client.sent_mail.subject).to eq('Hello, world!')


### PR DESCRIPTION
@apartmentlist/supply

Now this gem works with emails of the form `Taco Cat <taco@cat.limo>`, which
previously would fail because the SendGrid API requires `from` to be a simple
email address.

The `mail` gem changed between v2.5.\* and v2.6.\* to rename
`mail[:from].tree` to `mail[:from].address_list` (which is a much better
name), but ActionMailer 4 requires ~>2.5.3. Rails 4 is now two years old, and
sendgrid-actionmailer is intended for use with ActionMailer, so the 2.5.*
series that ActionMailer requires seems reasonable. In fact, it might be
reasonable to depend on a particular version of ActionMailer itself, but
that's more than we specifically need so far.
