### PR TITLE
Add CC and BCC fields

### DIFF
--- a/lib/sendgrid-actionmailer.rb
+++ b/lib/sendgrid-actionmailer.rb
@@ -21,6 +21,8 @@ module SendGridActionMailer
 
       email = SendGrid::Mail.new do |m|
         m.to        = mail[:to].addresses
+        m.cc        = mail[:cc].addresses  if mail[:cc]
+        m.bcc       = mail[:bcc].addresses if mail[:bcc]
         m.from      = from.address
         m.from_name = from.display_name
         m.subject   = mail.subject

--- a/spec/lib/sendgrid-actionmailer-spec.rb
+++ b/spec/lib/sendgrid-actionmailer-spec.rb
@@ -47,6 +47,24 @@ module SendGridActionMailer
         expect(client.sent_mail.from).to eq('taco@cat.limo')
       end
 
+      context 'there are ccs' do
+        before { mail.cc = 'burrito@cat.limo' }
+
+        it 'sets cc' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.cc).to eq(%w[burrito@cat.limo])
+        end
+      end
+
+      context 'there are bccs' do
+        before { mail.bcc = 'nachos@cat.limo' }
+
+        it 'sets bcc' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.bcc).to eq(%w[nachos@cat.limo])
+        end
+      end
+
       context 'from contains a friendly name' do
         before { mail.from = 'Taco Cat <taco@cat.limo>'}
 


### PR DESCRIPTION
@apartmentlist/supply

Add support for CC and BCCs. Since those fields are `nil` if not specified, I
declare them in a `context` so the main spec scope runs that path.
