### PR TITLE
Pass through SMTPAPI categories

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -23,6 +23,18 @@ module SendGridActionMailer
         m.subject = mail.subject
       end
 
+      smtpapi = mail['X-SMTPAPI']
+      if smtpapi && smtpapi.value
+        begin
+          data = JSON.parse(smtpapi.value)
+          Array(data['category']).each do |category|
+            email.smtpapi.add_category(category)
+          end
+        rescue JSON::ParserError
+          raise ArgumentError, "X-SMTPAPI is not JSON: #{smtpapi.value}"
+        end
+      end
+
       # TODO: This is pretty ugly
       case mail.mime_type
       when 'text/plain'

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -126,6 +126,44 @@ module SendGridActionMailer
           expect(attachment[:file].read).to eq(File.read(__FILE__))
         end
       end
+
+      context 'SMTPAPI' do
+        context 'it is not JSON' do
+          before { mail['X-SMTPAPI'] = '<xml>JSON sucks!</xml>' }
+
+          it 'raises a useful error' do
+            expect { mailer.deliver!(mail) }.to raise_error(
+              ArgumentError,
+              "X-SMTPAPI is not JSON: <xml>JSON sucks!</xml>"
+            )
+          end
+        end
+
+        context 'a category is present' do
+          before do
+            mail['X-SMTPAPI'] = { category: 'food_feline' }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.category).to include('food_feline')
+          end
+        end
+
+        context 'multiple categories are present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              category: %w[food_feline cuisine_canine]
+            }.to_json
+          end
+
+          it 'attaches them all' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.category)
+              .to include('food_feline', 'cuisine_canine')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The `SendGrid::Mail#smtpapi` object is nicely structured, so we can't blindly
pass through everything in the `X-SMTPAPI` header. This parses out the JSON
you set in your `ActionMailer::Base` subclass and passes the categories on.
